### PR TITLE
Fix a problem with unmounting image removing directory not created by fuseiso

### DIFF
--- a/ServiceMenus/ISO-Image-Tools_servicemenu.desktop
+++ b/ServiceMenus/ISO-Image-Tools_servicemenu.desktop
@@ -148,7 +148,7 @@ Name[zh_CN]=挂载 ISO-9660 镜像
 Name[x-test]=xxMount ISO-9660 Imagexx
 
 [Desktop Action UnmountCD-Image]
-Exec=which fuser fusermount; if [ "$?" != "0" ];then kdialog --icon=ks-error --title="Unmount ISO-9660 Image" --passivepopup="[Error] Please install fuser and fusermount command and try again."; exit 1; else fuser -k %f; fusermount -u "$(ls "%f"|sed 's/.iso$//')"; rm -fr "$(ls "%f"|sed 's/.iso$//')"; kdialog --icon=ks-media-optical-umount --title="Unmount ISO-9660 Image" --passivepopup="[Finished] $(basename %f) unmounted.";fi
+Exec=which fuser fusermount; if [ "$?" != "0" ];then kdialog --icon=ks-error --title="Unmount ISO-9660 Image" --passivepopup="[Error] Please install fuser and fusermount command and try again."; exit 1; else fuser -k %f; fusermount -u "$(ls "%f"|sed 's/.iso$//')" && rm -fr "$(ls "%f"|sed 's/.iso$//')"; kdialog --icon=ks-media-optical-umount --title="Unmount ISO-9660 Image" --passivepopup="[Finished] $(basename %f) unmounted.";fi
 Icon=ks-media-optical-umount
 Name=Unmount ISO-9660 Image
 Name[de]=ISO-9660 Abbild aushängen


### PR DESCRIPTION
I notice a problem with the script of KDE-Services and unmounting image that result in a directory in my machine being removed just because it had the same name as the directory that would be created by fuseiso.

My machine:

CachyOS 12.12.1
KDE Plasma 6.3.0
Dolphin 24.12.2
KDE-Services  3.0.7

The problem occur because the `rm` script is ran even when fusermount results in false. Changing it to `&&` avoids this problem.