### PR TITLE
Fix whitespace handling in absolute paths for certain service menus

### DIFF
--- a/applications/CheckSum_Tools-verify-checksum.sh
+++ b/applications/CheckSum_Tools-verify-checksum.sh
@@ -84,10 +84,7 @@ progressbar-stop() {
 
 progressbar-start
 
-FILE=$(echo "$FILE" | sed -E 's/\.(md5|sha1|sha256|sha512)[[:space:]]+/\.\1\
-/gI' | sed 's/[[:space:]]*$//')
-
-for file in $FILE; do
+for file in "$FILE"; do
 	cd "${file%/*}"
 	DIR="$(pwd)"
 	CHECKSUMFILE=${file##*.}

--- a/applications/CheckSum_Tools-verify-checksum.sh
+++ b/applications/CheckSum_Tools-verify-checksum.sh
@@ -83,7 +83,7 @@ progressbar-stop() {
 
 progressbar-start
 
-for file in $FILE; do
+for file in "$FILE"; do
 	cd "${file%/*}"
 
 	DIR="$(pwd)"

--- a/applications/CheckSum_Tools-verify-checksum.sh
+++ b/applications/CheckSum_Tools-verify-checksum.sh
@@ -85,37 +85,6 @@ progressbar-start
 
 for file in $FILE; do
 	cd "${file%/*}"
-	mv "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")")")")")")")" \
-		"$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")")")")")")"|\
-		sed 's/ /_/g')" 2>/dev/null
-	cd ./
-	mv "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")")")")")")" "$(dirname \
-		"$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")")")")")"|sed 's/ /_/g')" 2>/dev/null
-	cd ./
-	mv "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")")")")")" "$(dirname "$(dirname \
-		"$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")")")")"|sed 's/ /_/g')" 2>/dev/null
-	cd ./
-	mv "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")")")")" "$(dirname "$(dirname "$(dirname \
-		"$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")")")"|sed 's/ /_/g')" 2>/dev/null
-	cd ./
-	mv "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")")")" "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname \
-		"$(pwd|grep " ")")")")")"|sed 's/ /_/g')" 2>/dev/null
-	cd ./
-	mv "$(dirname "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")")" "$(dirname "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")"|\
-		sed 's/ /_/g')" 2>/dev/null
-	cd ./
-	mv "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")" "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")"|sed 's/ /_/g')" 2>/dev/null
-	cd ./
-	mv "$(dirname "$(dirname "$(pwd|grep " ")")")" "$(dirname "$(dirname "$(pwd|grep " ")")"|sed 's/ /_/g')" 2>/dev/null
-	cd ./
-	mv "$(dirname "$(pwd|grep " ")")" "$(dirname "$(pwd|grep " ")"|sed 's/ /_/g')" 2>/dev/null
-	cd ./
-	mv "$(pwd|grep " ")" "$(pwd|grep " "|sed 's/ /_/g')" 2>/dev/null
-	cd ./
-
-	for i in *; do
-		mv "$i" "${i// /_}" 2>/dev/null
-	done
 
 	DIR="$(pwd)"
 	CHECKSUMFILE=${file##*.}

--- a/applications/CheckSum_Tools-verify-checksum.sh
+++ b/applications/CheckSum_Tools-verify-checksum.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ###################################################################################
-# KDE-Services ⚙ 2011-2025.                                                       #
+# KDE-Services ⚙ 2011-2026.                                                       #
 #                                                                                 #
 # BSD 3-Clause License                                                            #
 #                                                                                 #
@@ -37,6 +37,7 @@ ELAPSED_TIME=""
 FILE=$@
 FINAL_TIME=""
 HASH=""
+IFS=$'\n'
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:~/bin
 PB_PIDFILE="$(mktemp)"
 TMP=$(mktemp)
@@ -83,12 +84,14 @@ progressbar-stop() {
 
 progressbar-start
 
-for file in "$FILE"; do
-	cd "${file%/*}"
+FILE=$(echo "$FILE" | sed -E 's/\.(md5|sha1|sha256|sha512)[[:space:]]+/\.\1\
+/gI' | sed 's/[[:space:]]*$//')
 
+for file in $FILE; do
+	cd "${file%/*}"
 	DIR="$(pwd)"
 	CHECKSUMFILE=${file##*.}
-	
+
 	if [ "$CHECKSUMFILE" != "md5" ] && [ "$CHECKSUMFILE" != "MD5" ] && [ "$CHECKSUMFILE" != "sha1" ] && [ "$CHECKSUMFILE" != "SHA1" ] && \
 		[ "$CHECKSUMFILE" != "sha256" ] && [ "$CHECKSUMFILE" != "SHA256" ] && [ "$CHECKSUMFILE" != "sha512" ] && [ "$CHECKSUMFILE" != "SHA512" ]; then
 		kdialog --icon=ks-error --title="Verify CheckSum" \

--- a/applications/Compressed_file_integrity_check.sh
+++ b/applications/Compressed_file_integrity_check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ###################################################################################
-# KDE-Services ⚙ 2014-2025.                                                       #
+# KDE-Services ⚙ 2014-2026.                                                       #
 #                                                                                 #
 # BSD 3-Clause License                                                            #
 #                                                                                 #
@@ -37,14 +37,13 @@ ELAPSED_TIME=""
 EXIT=""
 FILE=$@
 FINAL_TIME=""
+IFS=$'\n'
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:~/bin
 PB_PIDFILE="$(mktemp)"
 
 ###################################
 ############# Functions ###########
 ###################################
-
-IFS=$'\n'
 
 progressbar-start() {
 	kdialog --icon=ks-compressed-file --title="Compressed File Integrity Check" --print-winid --progressbar "$(date) - Processing..." /ProcessDialog|grep -o '[[:digit:]]*' > $PB_PIDFILE
@@ -73,7 +72,7 @@ elapsedtime() {
 exit-check() {
 	if [ "$EXIT" = "1" ]; then
 		kdialog --icon=ks-error --title="Compressed File Integrity Check" \
-			--passivepopup="[Error]  ${file##*/}   Archive parsing failed! Please ensure only one file is selected! (Data is corrupted.)"
+			--passivepopup="[Error]  ${file##*/}   Archive parsing failed! (Data is corrupted.)"
 		exit 1
 	fi
 	while [ "$EXIT" = "2" ] || [ "$EXIT" = "1" ]; do
@@ -90,11 +89,12 @@ exit-check() {
 
 progressbar-start
 
+FILE=$(echo "$FILE" | sed -E 's/\.(7z|bcpio|bz|bz2|cab|cpio|cpio\.gz|deb|gz|iso|jar|lha|lzh|lzma|rar|rpm|sp|srpm|sv4cpio|sv4crc|tar|tar\.bz|tar\.bz2|tar\.gz|tar\.lzma|tar\.xz|tar\.Z|xz|Z|zip)[[:space:]]+/\.\1\
+/gI' | sed 's/[[:space:]]*$//')
+
 for file in $FILE; do
 	cd "${file%/*}"
-
 	DIR="$(pwd)"
-
 	BEGIN_TIME=$(date +%s)
 	lsar -t $file &>/dev/null
 	EXIT=$?

--- a/applications/Compressed_file_integrity_check.sh
+++ b/applications/Compressed_file_integrity_check.sh
@@ -44,6 +44,8 @@ PB_PIDFILE="$(mktemp)"
 ############# Functions ###########
 ###################################
 
+IFS=$'\n'
+
 progressbar-start() {
 	kdialog --icon=ks-compressed-file --title="Compressed File Integrity Check" --print-winid --progressbar "$(date) - Processing..." /ProcessDialog|grep -o '[[:digit:]]*' > $PB_PIDFILE
 }
@@ -71,7 +73,7 @@ elapsedtime() {
 exit-check() {
 	if [ "$EXIT" = "1" ]; then
 		kdialog --icon=ks-error --title="Compressed File Integrity Check" \
-			--passivepopup="[Error]  ${file##*/}   Archive parsing failed! (Data is corrupted.)"
+			--passivepopup="[Error]  ${file##*/}   Archive parsing failed! Please ensure only one file is selected! (Data is corrupted.)"
 		exit 1
 	fi
 	while [ "$EXIT" = "2" ] || [ "$EXIT" = "1" ]; do
@@ -90,38 +92,6 @@ progressbar-start
 
 for file in $FILE; do
 	cd "${file%/*}"
-
-	mv "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")")")")")")")" \
-		"$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")")")")")")"|\
-		sed 's/ /_/g')" 2>/dev/null
-	cd ./
-	mv "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")")")")")")" "$(dirname \
-		"$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")")")")")"|sed 's/ /_/g')" 2>/dev/null
-	cd ./
-	mv "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")")")")")" "$(dirname "$(dirname \
-		"$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")")")")"|sed 's/ /_/g')" 2>/dev/null
-	cd ./
-	mv "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")")")")" "$(dirname "$(dirname "$(dirname \
-		"$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")")")"|sed 's/ /_/g')" 2>/dev/null
-	cd ./
-	mv "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")")")" "$(dirname "$(dirname "$(dirname "$(dirname "$(dirname \
-		"$(pwd|grep " ")")")")")"|sed 's/ /_/g')" 2>/dev/null
-	cd ./
-	mv "$(dirname "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")")" "$(dirname "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")"|\
-		sed 's/ /_/g')" 2>/dev/null
-	cd ./
-	mv "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")")" "$(dirname "$(dirname "$(dirname "$(pwd|grep " ")")")"|sed 's/ /_/g')" 2>/dev/null
-	cd ./
-	mv "$(dirname "$(dirname "$(pwd|grep " ")")")" "$(dirname "$(dirname "$(pwd|grep " ")")"|sed 's/ /_/g')" 2>/dev/null
-	cd ./
-	mv "$(dirname "$(pwd|grep " ")")" "$(dirname "$(pwd|grep " ")"|sed 's/ /_/g')" 2>/dev/null
-	cd ./
-	mv "$(pwd|grep " ")" "$(pwd|grep " "|sed 's/ /_/g')" 2>/dev/null
-	cd ./
-
-	for i in *; do
-		mv "$i" "${i// /_}" 2>/dev/null
-	done
 
 	DIR="$(pwd)"
 

--- a/applications/Compressed_file_integrity_check.sh
+++ b/applications/Compressed_file_integrity_check.sh
@@ -89,10 +89,7 @@ exit-check() {
 
 progressbar-start
 
-FILE=$(echo "$FILE" | sed -E 's/\.(7z|bcpio|bz|bz2|cab|cpio|cpio\.gz|deb|gz|iso|jar|lha|lzh|lzma|rar|rpm|sp|srpm|sv4cpio|sv4crc|tar|tar\.bz|tar\.bz2|tar\.gz|tar\.lzma|tar\.xz|tar\.Z|xz|Z|zip)[[:space:]]+/\.\1\
-/gI' | sed 's/[[:space:]]*$//')
-
-for file in $FILE; do
+for file in "$FILE"; do
 	cd "${file%/*}"
 	DIR="$(pwd)"
 	BEGIN_TIME=$(date +%s)

--- a/applications/DVD_Tools-d.v.d.-assembler.sh
+++ b/applications/DVD_Tools-d.v.d.-assembler.sh
@@ -90,9 +90,13 @@ if [ "$DIR" == "~/.local/share/applications" ]; then
 	DIR="~/"
 fi
 
+IFS=$'\n'
+
 FILES=$(kdialog --icon=ks-media-optical-video --title="Source Video Files" --multiple \
 		--getopenfilename "$DIR" "*.mp2 *.mpe *.mpeg *.mpg *.vob *.MP2 *.MPE *.MPEG *.MPG *.VOB|MPEG-2 files" 2> /dev/null)
 if-cancel-exit
+
+FILES=$(echo "$FILES" | sed -E 's/\.(mp2|mpe|mpeg|mpg|vob)\s/\.\1\n/gi')
 
 for VIDEO in $FILES; do
 	ffprobe "$VIDEO" 2> $VIDEOINFO
@@ -120,12 +124,14 @@ progressbar-start
 
 BEGIN_TIME=$(date +%s)
 
-dvdauthor -tf $FILES -O $DESTINATION/$DVD_NAME
+dvdauthor -tf $FILES -O "$DESTINATION/$DVD_NAME"
 if-dvdauthor-cancel
 
-genisoimage -R -J -o $DESTINATION/$DVD_NAME.iso $DESTINATION/$DVD_NAME
+unset IFS
 
-rm -fr $DESTINATION/$DVD_NAME
+genisoimage -R -J -o "$DESTINATION/$DVD_NAME.iso" "$DESTINATION/$DVD_NAME"
+
+rm -fr "$DESTINATION/$DVD_NAME"
 progressbar-stop
 
 FINAL_TIME=$(date +%s)

--- a/applications/DVD_Tools-d.v.d.-assembler.sh
+++ b/applications/DVD_Tools-d.v.d.-assembler.sh
@@ -96,7 +96,7 @@ FILES=$(kdialog --icon=ks-media-optical-video --title="Source Video Files" --mul
 		--getopenfilename "$DIR" "*.mp2 *.mpe *.mpeg *.mpg *.vob *.MP2 *.MPE *.MPEG *.MPG *.VOB|MPEG-2 files" 2> /dev/null)
 if-cancel-exit
 
-FILES=$(echo "$FILES" | sed -E 's/\.(mp2|mpe|mpeg|mpg|vob)\s/\.\1\n/gi')
+FILES=$(echo "$FILES" | sed -E 's/\.(mp2|mpe|mpeg|mpg|vob)\s/\.\1\n/gi' | sed 's/ $//g')
 
 for VIDEO in $FILES; do
 	ffprobe "$VIDEO" 2> $VIDEOINFO

--- a/applications/DVD_Tools-d.v.d.-assembler.sh
+++ b/applications/DVD_Tools-d.v.d.-assembler.sh
@@ -40,6 +40,7 @@ DVD_NAME=""
 ELAPSED_TIME=""
 FILES=""
 FINAL_TIME=""
+IFS=$'\n'
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:~/bin
 PB_PIDFILE="$(mktemp)"
 PID="$$"
@@ -90,13 +91,12 @@ if [ "$DIR" == "~/.local/share/applications" ]; then
 	DIR="~/"
 fi
 
-IFS=$'\n'
-
 FILES=$(kdialog --icon=ks-media-optical-video --title="Source Video Files" --multiple \
 		--getopenfilename "$DIR" "*.mp2 *.mpe *.mpeg *.mpg *.vob *.MP2 *.MPE *.MPEG *.MPG *.VOB|MPEG-2 files" 2> /dev/null)
 if-cancel-exit
 
-FILES=$(echo "$FILES" | sed -E 's/\.(mp2|mpe|mpeg|mpg|vob)\s/\.\1\n/gi' | sed 's/ $//g')
+FILES=$(echo "$FILES" | sed -E 's/\.(mp2|mpe|mpeg|mpg|vob)[[:space:]]+/\.\1\
+/gI' | sed 's/[[:space:]]*$//')
 
 for VIDEO in $FILES; do
 	ffprobe "$VIDEO" 2> $VIDEOINFO
@@ -126,8 +126,6 @@ BEGIN_TIME=$(date +%s)
 
 dvdauthor -tf $FILES -O "$DESTINATION/$DVD_NAME"
 if-dvdauthor-cancel
-
-unset IFS
 
 genisoimage -R -J -o "$DESTINATION/$DVD_NAME.iso" "$DESTINATION/$DVD_NAME"
 

--- a/applications/DVD_Tools-d.v.d.-assembler.sh
+++ b/applications/DVD_Tools-d.v.d.-assembler.sh
@@ -64,7 +64,7 @@ if-dvdauthor-cancel() {
 		kill $(cat $PB_PIDFILE)
 		rm $PB_PIDFILE
 		kdialog --icon=ks-error --title="DVD Assembler ($DVD_NAME)" \
-			--passivepopup="[Canceled]   Check the path and filename not contain whitespaces. Check video format errors. Try again"
+			--passivepopup="[Canceled]   Check video format errors. Try again"
 		exit 1
 	fi
 }

--- a/applications/Multimedia_Tools-audio-normalize.sh
+++ b/applications/Multimedia_Tools-audio-normalize.sh
@@ -65,7 +65,7 @@ if-cancel-exit() {
 if-mp3gain-cancel() {
 	if [ "$?" != "0" ]; then
 		kdialog --icon=ks-error --title="Adjusting volume level of ${i##*/}" \
-			--passivepopup="[Canceled]   Check the path and filename not contain whitespaces. Check error log $LOGERROR. Try again"
+			--passivepopup="[Canceled]   Check error log $LOGERROR. Try again"
 		mv $LOG $DST_FILE/$LOGERROR
 		continue
 	fi
@@ -108,8 +108,12 @@ if [ "$DIR" == "~/.local/share/applications" ]; then
 	DIR="~/"
 fi
 
+IFS=$'\n'
+
 FILES=$(kdialog --icon=ks-audio-normalize --title="[Video|Audio] Files" --multiple --getopenfilename "$DIR" "*.MP3 *.mp3|*.mp3" 2>/dev/null)
 if-cancel-exit
+
+FILES=$(echo "$FILES" | sed -E 's/\.(mp3)\s/\.\1\n/gi' | sed 's/ $//g')
 
 progressbar-start
 

--- a/applications/Multimedia_Tools-audio-normalize.sh
+++ b/applications/Multimedia_Tools-audio-normalize.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ###################################################################################
-# KDE-Services ⚙ 2011-2025.                                                       #
+# KDE-Services ⚙ 2011-2026.                                                       #
 #                                                                                 #
 # BSD 3-Clause License                                                            #
 #                                                                                 #
@@ -37,6 +37,7 @@ DIR=""
 DST_FILE=""
 ELAPSED_TIME=""
 FINAL_TIME=""
+IFS=$'\n'
 LOG=""
 LOGERROR=""
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:~/bin
@@ -108,12 +109,11 @@ if [ "$DIR" == "~/.local/share/applications" ]; then
 	DIR="~/"
 fi
 
-IFS=$'\n'
-
 FILES=$(kdialog --icon=ks-audio-normalize --title="[Video|Audio] Files" --multiple --getopenfilename "$DIR" "*.MP3 *.mp3|*.mp3" 2>/dev/null)
 if-cancel-exit
 
-FILES=$(echo "$FILES" | sed -E 's/\.(mp3)\s/\.\1\n/gi' | sed 's/ $//g')
+FILES=$(echo "$FILES" | sed -E 's/\.(mp3)[[:space:]]+/\.\1\
+/gI' | sed 's/[[:space:]]*$//')
 
 progressbar-start
 

--- a/applications/The_Converter.sh
+++ b/applications/The_Converter.sh
@@ -59,7 +59,7 @@ if-convert-cancel() {
 	if [ "$?" != "0" ]; then
 		kdialog --icon=ks-error --title="Image Converter" \
 			--passivepopup="[Canceled]   ${i##*/}                                             \
-			Check the path and filename not contain whitespaces. Check image format errors. Try again."
+			Check image format errors. Try again."
 		continue
 	fi
 }
@@ -100,11 +100,15 @@ if [ "$DIR" == "~/.local/share/applications" ]; then
 	DIR="~/"
 fi
 
+IFS=$'\n'
+
 FILES=$(kdialog --icon=ks-image --title="Source Image Files" --multiple \
 		--getopenfilename "$DIR" "*.bmp *.eps *.gif *.ico *.jp2 *.jpeg *.jpg *.pbm *.pgm * *.ppm *.psd *.sgi *.svg \
 		*.tga *.tif *.tiff *.xpm *.BMP *.EPS *.GIF *.ICO *.JP2 *.JPEG *.JPG *.PBM *.PGM *.PNG *.PPM *.PSD *.SGI *.SVG *.TGA \
 		*.TIF *.TIFF *.XPM|*.bmp *.eps *.gif *.ico *.jp2 *.jpeg *.jpg *.pbm *.pgm * *.ppm *.psd *.sgi *.svg *.tga *.tif *.tiff *.xpm" 2> /dev/null)
 if-cancel-exit
+
+FILES=$(echo "$FILES" | sed -E 's/\.(bmp|eps|gif|ico|jp2|jpeg|jpg|pbm|pgm|ppm|psd|sgi|svg|tga|tif|tiff|xpm)\s/\.\1\n/gi' | sed 's/ $//g')
 
 DESTINATION=$(kdialog --icon=ks-image --title="Destination Image Files" --getexistingdirectory "$DIR" 2> /dev/null)
 if-cancel-exit

--- a/applications/The_Converter.sh
+++ b/applications/The_Converter.sh
@@ -39,6 +39,7 @@ ELAPSED_TIME=""
 FILES=""
 FINAL_TIME=""
 FORMAT=""
+IFS=$'\n'
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:~/bin
 PB_PIDFILE="$(mktemp)"
 
@@ -100,15 +101,14 @@ if [ "$DIR" == "~/.local/share/applications" ]; then
 	DIR="~/"
 fi
 
-IFS=$'\n'
-
 FILES=$(kdialog --icon=ks-image --title="Source Image Files" --multiple \
 		--getopenfilename "$DIR" "*.bmp *.eps *.gif *.ico *.jp2 *.jpeg *.jpg *.pbm *.pgm * *.ppm *.psd *.sgi *.svg \
 		*.tga *.tif *.tiff *.xpm *.BMP *.EPS *.GIF *.ICO *.JP2 *.JPEG *.JPG *.PBM *.PGM *.PNG *.PPM *.PSD *.SGI *.SVG *.TGA \
 		*.TIF *.TIFF *.XPM|*.bmp *.eps *.gif *.ico *.jp2 *.jpeg *.jpg *.pbm *.pgm * *.ppm *.psd *.sgi *.svg *.tga *.tif *.tiff *.xpm" 2> /dev/null)
 if-cancel-exit
 
-FILES=$(echo "$FILES" | sed -E 's/\.(bmp|eps|gif|ico|jp2|jpeg|jpg|pbm|pgm|ppm|psd|sgi|svg|tga|tif|tiff|xpm)\s/\.\1\n/gi' | sed 's/ $//g')
+FILES=$(echo "$FILES" | sed -E 's/\.(bmp|eps|gif|ico|jp2|jpeg|jpg|pbm|pgm|ppm|psd|sgi|svg|tga|tif|tiff|xpm)[[:space:]]+/\.\1\
+/gI' | sed 's/[[:space:]]*$//')
 
 DESTINATION=$(kdialog --icon=ks-image --title="Destination Image Files" --getexistingdirectory "$DIR" 2> /dev/null)
 if-cancel-exit

--- a/applications/The_Resizer.sh
+++ b/applications/The_Resizer.sh
@@ -100,11 +100,15 @@ if [ "$DIR" == "~/.local/share/applications" ]; then
 	DIR="~/"
 fi
 
+IFS=$'\n'
+
 FILES=$(kdialog --icon=ks-resize-image --title="Source Image Files" --multiple \
 		--getopenfilename "$DIR" "*.bmp *.eps *.gif *.ico *.jp2 *.jpeg *.jpg *.pbm *.pgm * *.ppm *.psd *.sgi \
 		*.tga *.tif *.tiff *.xpm *.BMP *.EPS *.GIF *.ICO *.JP2 *.JPEG *.JPG *.PBM *.PGM *.PNG *.PPM *.PSD *.SGI *.TGA \
 		*.TIF *.TIFF *.XPM|*.bmp *.eps *.gif *.ico *.jp2 *.jpeg *.jpg *.pbm *.pgm * *.ppm *.psd *.sgi *.tga *.tif *.tiff *.xpm" 2> /dev/null)
 if-cancel-exit
+
+FILES=$(echo "$FILES" | sed -E 's/\.(bmp|eps|gif|ico|jp2|jpeg|jpg|pbm|pgm|ppm|psd|sgi|tga|tif|tiff|xpm)\s/\.\1\n/gi' | sed 's/ $//g')
 
 DESTINATION=$(kdialog --icon=ks-resize-image --title="Destination Image Files" --getexistingdirectory "$DIR" 2> /dev/null)
 if-cancel-exit
@@ -117,7 +121,7 @@ progressbar-start
 
 for i in $FILES; do
 	DST_FILE="${i%.*}"
-	magick -resize $SIZE "$i" "$DESTINATION/${DST_FILE##*/}_${SIZE}p.${i:${#i}-3}"
+	magick $i -resize $SIZE "$DESTINATION/${DST_FILE##*/}_${SIZE}p.${i:${#i}-3}"
 	if-convert-cancel
 done
 

--- a/applications/The_Resizer.sh
+++ b/applications/The_Resizer.sh
@@ -38,6 +38,7 @@ DIR=""
 ELAPSED_TIME=""
 FILES=""
 FINAL_TIME=""
+IFS=$'\n'
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:~/bin
 PB_PIDFILE="$(mktemp)"
 SIZE=""
@@ -100,15 +101,14 @@ if [ "$DIR" == "~/.local/share/applications" ]; then
 	DIR="~/"
 fi
 
-IFS=$'\n'
-
 FILES=$(kdialog --icon=ks-resize-image --title="Source Image Files" --multiple \
 		--getopenfilename "$DIR" "*.bmp *.eps *.gif *.ico *.jp2 *.jpeg *.jpg *.pbm *.pgm * *.ppm *.psd *.sgi \
 		*.tga *.tif *.tiff *.xpm *.BMP *.EPS *.GIF *.ICO *.JP2 *.JPEG *.JPG *.PBM *.PGM *.PNG *.PPM *.PSD *.SGI *.TGA \
 		*.TIF *.TIFF *.XPM|*.bmp *.eps *.gif *.ico *.jp2 *.jpeg *.jpg *.pbm *.pgm * *.ppm *.psd *.sgi *.tga *.tif *.tiff *.xpm" 2> /dev/null)
 if-cancel-exit
 
-FILES=$(echo "$FILES" | sed -E 's/\.(bmp|eps|gif|ico|jp2|jpeg|jpg|pbm|pgm|ppm|psd|sgi|tga|tif|tiff|xpm)\s/\.\1\n/gi' | sed 's/ $//g')
+FILES=$(echo "$FILES" | sed -E 's/\.(bmp|eps|gif|ico|jp2|jpeg|jpg|pbm|pgm|ppm|psd|sgi|tga|tif|tiff|xpm)[[:space:]]+/\.\1\
+/gI' | sed 's/[[:space:]]*$//')
 
 DESTINATION=$(kdialog --icon=ks-resize-image --title="Destination Image Files" --getexistingdirectory "$DIR" 2> /dev/null)
 if-cancel-exit
@@ -121,7 +121,7 @@ progressbar-start
 
 for i in $FILES; do
 	DST_FILE="${i%.*}"
-	magick $i -resize $SIZE "$DESTINATION/${DST_FILE##*/}_${SIZE}p.${i:${#i}-3}"
+	magick $i -resize $SIZE "$DESTINATION/${DST_FILE##*/} (${SIZE}p).${i##*.}"
 	if-convert-cancel
 done
 

--- a/applications/ffmpeg_multifile-add-subtitle.sh
+++ b/applications/ffmpeg_multifile-add-subtitle.sh
@@ -42,6 +42,8 @@ LOGERROR=""
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:~/bin
 PB_PIDFILE="$(mktemp)"
 
+IFS=$'\n'
+
 ###################################
 ############ Functions ############
 ###################################
@@ -64,7 +66,7 @@ if-cancel-exit() {
 if-ffmpeg-cancel() {
 	if [ "$?" != "0" ]; then
 		kdialog --icon=ks-error --title="Adding ${SUBS[$ARRAY_NUMBER]##*/} to ${FILES[$ARRAY_NUMBER]##*/}" \
-			--passivepopup="[Canceled]   Check the path and filename not contain whitespaces. Check error log $LOGERROR. Try again"
+			--passivepopup="[Canceled]   Check error log $LOGERROR. Try again"
 		mv $LOG $DESTINATION/$LOGERROR
 		continue
 	fi
@@ -110,8 +112,12 @@ fi
 FILES=($(kdialog --icon=ks-add-subs --title="Video Files" --multiple --getopenfilename "$DIR" "*.MP4 *.mp4|*.mp4" 2>/dev/null))
 if-cancel-exit
 
+mapfile -t FILES <<< "$(echo "$FILES" | sed -E 's/\.(mp4)\s/\.\1\n/gi' | sed 's/ $//g')"
+
 SUBS=($(kdialog --icon=ks-add-subs --title="Subtitle Files" --multiple --getopenfilename "$DIR" "*.SRT *.srt|*.srt" 2>/dev/null))
 if-cancel-exit
+
+mapfile -t SUBS <<< "$(echo "$SUBS" | sed -E 's/\.(srt)\s/\.\1\n/gi' | sed 's/ $//g')"
 
 DESTINATION=$(kdialog --icon=ks-add-subs --title="Destination Video Files" --getexistingdirectory "$DIR" 2>/dev/null)
 if-cancel-exit

--- a/applications/ffmpeg_multifile-add-subtitle.sh
+++ b/applications/ffmpeg_multifile-add-subtitle.sh
@@ -37,12 +37,11 @@ DESTINATION=""
 DIR=""
 ELAPSED_TIME=""
 FINAL_TIME=""
+IFS=$'\n'
 LOG=""
 LOGERROR=""
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:~/bin
 PB_PIDFILE="$(mktemp)"
-
-IFS=$'\n'
 
 ###################################
 ############ Functions ############
@@ -112,12 +111,14 @@ fi
 FILES=($(kdialog --icon=ks-add-subs --title="Video Files" --multiple --getopenfilename "$DIR" "*.MP4 *.mp4|*.mp4" 2>/dev/null))
 if-cancel-exit
 
-mapfile -t FILES <<< "$(echo "$FILES" | sed -E 's/\.(mp4)\s/\.\1\n/gi' | sed 's/ $//g')"
+mapfile -t FILES <<< "$(echo "$FILES" | sed -E 's/\.(mp4)[[:space:]]+/\.\1\
+/gI' | sed 's/[[:space:]]*$//')"
 
 SUBS=($(kdialog --icon=ks-add-subs --title="Subtitle Files" --multiple --getopenfilename "$DIR" "*.SRT *.srt|*.srt" 2>/dev/null))
 if-cancel-exit
 
-mapfile -t SUBS <<< "$(echo "$SUBS" | sed -E 's/\.(srt)\s/\.\1\n/gi' | sed 's/ $//g')"
+mapfile -t SUBS <<< "$(echo "$SUBS" | sed -E 's/\.(srt)[[:space:]]+/\.\1\
+/gI' | sed 's/[[:space:]]*$//')"
 
 DESTINATION=$(kdialog --icon=ks-add-subs --title="Destination Video Files" --getexistingdirectory "$DIR" 2>/dev/null)
 if-cancel-exit

--- a/applications/ffmpeg_multifile-audio-mp3-attach-cover.sh
+++ b/applications/ffmpeg_multifile-audio-mp3-attach-cover.sh
@@ -37,6 +37,7 @@ DESTINATION=""
 DIR=""
 ELAPSED_TIME=""
 FINAL_TIME=""
+IFS=$'\n'
 LOG=""
 LOGERROR=""
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:~/bin
@@ -112,12 +113,11 @@ COVER=$(kdialog --icon=ks-audio-mp3-attach-cover --title="Picture File" \
 		--getopenfilename "$DIR" "*.bmp *.gif *.jp2 *.jpeg *.jpg * *.tif *.tiff *.BMP *.GIF *.JP2 *.JPEG *.JPG *.PNG *.TIF *.TIFF|*.bmp *.gif *.jp2 *.jpeg *.jpg * *.tif *.tiff" 2>/dev/null)
 if-cancel-exit
 
-IFS=$'\n'
-
 FILES=$(kdialog --icon=ks-audio-mp3-attach-cover --title="Audio MP3 Files" --multiple --getopenfilename "$DIR" "*.MP3 *.mp3|*.mp3" 2>/dev/null)
 if-cancel-exit
 
-FILES=$(echo "$FILES" | sed -E 's/\.(mp3)\s/\.\1\n/gi' | sed 's/ $//g')
+FILES=$(echo "$FILES" | sed -E 's/\.(mp3)[[:space:]]+/\.\1\
+/gI' | sed 's/[[:space:]]*$//')
 
 DESTINATION=$(kdialog --icon=ks-audio-mp3-attach-cover --title="Destination Audio Files" --getexistingdirectory "$DIR" 2>/dev/null)
 if-cancel-exit

--- a/applications/ffmpeg_multifile-audio-mp3-attach-cover.sh
+++ b/applications/ffmpeg_multifile-audio-mp3-attach-cover.sh
@@ -65,7 +65,7 @@ if-cancel-exit() {
 if-ffmpeg-cancel() {
 	if [ "$?" != "0" ]; then
 		kdialog --icon=ks-error --title="Attaching ${COVER##*/} to ${i##*/}" \
-			--passivepopup="[Canceled]   Check the path and filename not contain whitespaces. Check error log $LOGERROR. Try again"
+			--passivepopup="[Canceled]   Check error log $LOGERROR. Try again"
 		mv $LOG $DESTINATION/$LOGERROR
 		continue
 	fi
@@ -112,8 +112,12 @@ COVER=$(kdialog --icon=ks-audio-mp3-attach-cover --title="Picture File" \
 		--getopenfilename "$DIR" "*.bmp *.gif *.jp2 *.jpeg *.jpg * *.tif *.tiff *.BMP *.GIF *.JP2 *.JPEG *.JPG *.PNG *.TIF *.TIFF|*.bmp *.gif *.jp2 *.jpeg *.jpg * *.tif *.tiff" 2>/dev/null)
 if-cancel-exit
 
+IFS=$'\n'
+
 FILES=$(kdialog --icon=ks-audio-mp3-attach-cover --title="Audio MP3 Files" --multiple --getopenfilename "$DIR" "*.MP3 *.mp3|*.mp3" 2>/dev/null)
 if-cancel-exit
+
+FILES=$(echo "$FILES" | sed -E 's/\.(mp3)\s/\.\1\n/gi' | sed 's/ $//g')
 
 DESTINATION=$(kdialog --icon=ks-audio-mp3-attach-cover --title="Destination Audio Files" --getexistingdirectory "$DIR" 2>/dev/null)
 if-cancel-exit

--- a/applications/ffmpeg_multifile-clean-metadata-media-file.sh
+++ b/applications/ffmpeg_multifile-clean-metadata-media-file.sh
@@ -37,6 +37,7 @@ DESTINATION=""
 DIR=""
 ELAPSED_TIME=""
 FINAL_TIME=""
+IFS=$'\n'
 LOG=""
 LOGERROR=""
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:~/bin
@@ -108,14 +109,13 @@ if [ "$DIR" == "~/.local/share/applications" ]; then
 	DIR="~/"
 fi
 
-IFS=$'\n'
-
 FILES=$(kdialog --icon=ks-media-clean-metadata --title="Media Files" --multiple --getopenfilename "$DIR" "*.3GP *.3gp *.AVI *.avi *.DAT \
 	*.dat *.DV *.dv *.FLAC *.flac *.FLV *.flv *.M2V *.m2v *.M4A *.m4a *.M4V *.m4v *.MKV *.mkv *.MOV *.mov *.MP3 *.mp3 *.MP4 *.mp4 *.MPG *.mpg *.OGG *.ogg *.OGV *.ogv *.VOB *.vob *.WAV *.wav \
 	*.WEBM *.webm *.WMA *.wma *.WMV *.wmv|*.3gp *.avi *.dat *.dv *.flac *.flv *.m2v *.m4a *.m4v *.mkv *.mov *.mp3 *.mp4 *.mpg *.ogg *.ogv *.vob *.wav *.webm *.wma *.wmv" 2>/dev/null)
 if-cancel-exit
 
-FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flac|flv|m2v|m4a|m4v|mkv|mov|mp3|mp4|mpg|ogg|ogv|vob|wav|webm|wma|wmv)\s/\.\1\n/gi' | sed 's/ $//g')
+FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flac|flv|m2v|m4a|m4v|mkv|mov|mp3|mp4|mpg|ogg|ogv|vob|wav|webm|wma|wmv)[[:space:]]+/\.\1\
+/gI' | sed 's/[[:space:]]*$//')
 
 DESTINATION=$(kdialog --icon=ks-media-clean-metadata --title="Destination Media Files" --getexistingdirectory "$DIR" 2>/dev/null)
 if-cancel-exit
@@ -126,16 +126,16 @@ for i in $FILES; do
 	BEGIN_TIME=$(date +%s)
 	DST_FILE="${i%.*}"
 	if [ "$(file $i|grep -o FLAC)" == "FLAC" ]; then
-		ffmpeg -y -i $i -map_metadata -1 -c copy "$DESTINATION/${DST_FILE##*/}_CleanMetadata.flac" &> $LOG
+		ffmpeg -y -i $i -map_metadata -1 -c copy "$DESTINATION/${DST_FILE##*/} (cm).flac" &> $LOG
 		if-ffmpeg-cancel
 	elif [ "$(file $i|grep -o ID3)" == "ID3" ]; then
-		ffmpeg -y -i $i -vn -map_metadata -1 -c copy "$DESTINATION/${DST_FILE##*/}_CleanMetadata.mp3" &> $LOG
+		ffmpeg -y -i $i -vn -map_metadata -1 -c copy "$DESTINATION/${DST_FILE##*/} (cm).mp3" &> $LOG
 		if-ffmpeg-cancel
 	elif [ "$(file $i|grep -o WebM)" == "WebM" ]; then
-		ffmpeg -y -i $i -map_metadata -1 -c copy "$DESTINATION/${DST_FILE##*/}_CleanMetadata.webm" &> $LOG
+		ffmpeg -y -i $i -map_metadata -1 -c copy "$DESTINATION/${DST_FILE##*/} (cm).webm" &> $LOG
 		if-ffmpeg-cancel
 	else
-		ffmpeg -y -i $i -map_metadata -1 -c copy "$DESTINATION/${DST_FILE##*/}_CleanMetadata.${i:${#i}-3}" &> $LOG
+		ffmpeg -y -i $i -map_metadata -1 -c copy "$DESTINATION/${DST_FILE##*/} (cm).${i##*.}" &> $LOG
 		if-ffmpeg-cancel
 	fi
 	FINAL_TIME=$(date +%s)

--- a/applications/ffmpeg_multifile-clean-metadata-media-file.sh
+++ b/applications/ffmpeg_multifile-clean-metadata-media-file.sh
@@ -65,7 +65,7 @@ if-cancel-exit() {
 if-ffmpeg-cancel() {
 	if [ "$?" != "0" ]; then
 		kdialog --icon=ks-error --title="Cleaning Metadata from ${i##*/}" \
-			--passivepopup="[Canceled]   Check the path and filename not contain whitespaces. Check error log $LOGERROR. Try again"
+			--passivepopup="[Canceled]   Check error log $LOGERROR. Try again"
 		mv $LOG $DESTINATION/$LOGERROR
 		continue
 	fi
@@ -108,10 +108,14 @@ if [ "$DIR" == "~/.local/share/applications" ]; then
 	DIR="~/"
 fi
 
+IFS=$'\n'
+
 FILES=$(kdialog --icon=ks-media-clean-metadata --title="Media Files" --multiple --getopenfilename "$DIR" "*.3GP *.3gp *.AVI *.avi *.DAT \
 	*.dat *.DV *.dv *.FLAC *.flac *.FLV *.flv *.M2V *.m2v *.M4A *.m4a *.M4V *.m4v *.MKV *.mkv *.MOV *.mov *.MP3 *.mp3 *.MP4 *.mp4 *.MPG *.mpg *.OGG *.ogg *.OGV *.ogv *.VOB *.vob *.WAV *.wav \
 	*.WEBM *.webm *.WMA *.wma *.WMV *.wmv|*.3gp *.avi *.dat *.dv *.flac *.flv *.m2v *.m4a *.m4v *.mkv *.mov *.mp3 *.mp4 *.mpg *.ogg *.ogv *.vob *.wav *.webm *.wma *.wmv" 2>/dev/null)
 if-cancel-exit
+
+FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flac|flv|m2v|m4a|m4v|mkv|mov|mp3|mp4|mpg|ogg|ogv|vob|wav|webm|wma|wmv)\s/\.\1\n/gi' | sed 's/ $//g')
 
 DESTINATION=$(kdialog --icon=ks-media-clean-metadata --title="Destination Media Files" --getexistingdirectory "$DIR" 2>/dev/null)
 if-cancel-exit

--- a/applications/ffmpeg_multifile-concatenate-media-file.sh
+++ b/applications/ffmpeg_multifile-concatenate-media-file.sh
@@ -124,7 +124,7 @@ FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flac|flv|m2v|m4a|m4v|mkv|mov
 /gI' | sed 's/[[:space:]]*$//')
 
 FILENAME=$(kdialog --icon=ks-concatenate-media-file --title="Concatenate Media Files with Same Codec" \
-			--inputbox="Enter filename for new concatenated media file" New_Concatenated_Media_File)
+			--inputbox="Enter filename for new concatenated media file" New Concatenated Media File)
 if-cancel-exit
 
 DESTINATION=$(kdialog --icon=ks-concatenate-media-file --title="Destination Media Files" --getexistingdirectory "$DIR" 2>/dev/null)

--- a/applications/ffmpeg_multifile-concatenate-media-file.sh
+++ b/applications/ffmpeg_multifile-concatenate-media-file.sh
@@ -39,6 +39,7 @@ ELAPSED_TIME=""
 FILE_LIST="/tmp/ConcatenateMediaFilesSameCodec"
 FILENAME=""
 FINAL_TIME=""
+IFS=$'\n'
 LOG=""
 LOGERROR=""
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:~/bin
@@ -114,14 +115,13 @@ if [ "$DIR" == "~/.local/share/applications" ]; then
 	DIR="~/"
 fi
 
-IFS=$'\n'
-
 FILES=$(kdialog --icon=ks-concatenate-media-file --title="Concatenate Media Files with Same Codec" --multiple --getopenfilename "$DIR" "*.3GP *.3gp *.AVI *.avi *.DAT \
 	*.dat *.DV *.dv *.FLAC *.flac *.FLV *.flv *.M2V *.m2v *.M4A *.m4a *.M4V *.m4v *.MKV *.mkv *.MOV *.mov *.MP3 *.mp3 *.MP4 *.mp4 *.MPEG *.mpeg *.MPEG4 *.mpeg4 *.MPG *.mpg *.OGG *.ogg *.OGV *.ogv *.VOB *.vob \
 	*.WAV *.wav *.WEBM *.webm *.WMA *.wma *.WMV *.wmv|*.3gp *.avi *.dat *.dv *.flac *.flv *.m2v *.m4a *.m4v *.mkv *.mov *.mp3 *.mp4 *.mpeg *.mpeg4 *.mpg *.ogg *.ogv *.vob *.wav *.webm *.wma *.wmv" 2>/dev/null)
 if-cancel-exit
 
-FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flac|flv|m2v|m4a|m4v|mkv|mov|mp3|mp4|mpeg|mpeg4|mpg|ogg|ogv|vob|wav|webm|wma|wmv)\s/\.\1\n/gi' | sed 's/ $//g')
+FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flac|flv|m2v|m4a|m4v|mkv|mov|mp3|mp4|mpeg|mpeg4|mpg|ogg|ogv|vob|wav|webm|wma|wmv)[[:space:]]+/\.\1\
+/gI' | sed 's/[[:space:]]*$//')
 
 FILENAME=$(kdialog --icon=ks-concatenate-media-file --title="Concatenate Media Files with Same Codec" \
 			--inputbox="Enter filename for new concatenated media file" New_Concatenated_Media_File)

--- a/applications/ffmpeg_multifile-concatenate-media-file.sh
+++ b/applications/ffmpeg_multifile-concatenate-media-file.sh
@@ -67,7 +67,7 @@ if-cancel-exit() {
 if-ffmpeg-cancel() {
 	if [ "$?" != "0" ]; then
 		kdialog --icon=ks-error --title="Concatenating $FILENAME" \
-			--passivepopup="[Canceled]   Check the path and filename not contain whitespaces. Check error log $LOGERROR. Try again"
+			--passivepopup="[Canceled]   Check error log $LOGERROR. Try again"
 		mv $LOG $DESTINATION/$LOGERROR
 		continue
 	fi
@@ -114,13 +114,17 @@ if [ "$DIR" == "~/.local/share/applications" ]; then
 	DIR="~/"
 fi
 
+IFS=$'\n'
+
 FILES=$(kdialog --icon=ks-concatenate-media-file --title="Concatenate Media Files with Same Codec" --multiple --getopenfilename "$DIR" "*.3GP *.3gp *.AVI *.avi *.DAT \
 	*.dat *.DV *.dv *.FLAC *.flac *.FLV *.flv *.M2V *.m2v *.M4A *.m4a *.M4V *.m4v *.MKV *.mkv *.MOV *.mov *.MP3 *.mp3 *.MP4 *.mp4 *.MPEG *.mpeg *.MPEG4 *.mpeg4 *.MPG *.mpg *.OGG *.ogg *.OGV *.ogv *.VOB *.vob \
 	*.WAV *.wav *.WEBM *.webm *.WMA *.wma *.WMV *.wmv|*.3gp *.avi *.dat *.dv *.flac *.flv *.m2v *.m4a *.m4v *.mkv *.mov *.mp3 *.mp4 *.mpeg *.mpeg4 *.mpg *.ogg *.ogv *.vob *.wav *.webm *.wma *.wmv" 2>/dev/null)
 if-cancel-exit
 
+FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flac|flv|m2v|m4a|m4v|mkv|mov|mp3|mp4|mpeg|mpeg4|mpg|ogg|ogv|vob|wav|webm|wma|wmv)\s/\.\1\n/gi' | sed 's/ $//g')
+
 FILENAME=$(kdialog --icon=ks-concatenate-media-file --title="Concatenate Media Files with Same Codec" \
-			--inputbox="Enter filename without whitespaces for new concatenated media file" New_Concatenated_Media_File)
+			--inputbox="Enter filename for new concatenated media file" New_Concatenated_Media_File)
 if-cancel-exit
 
 DESTINATION=$(kdialog --icon=ks-concatenate-media-file --title="Destination Media Files" --getexistingdirectory "$DIR" 2>/dev/null)

--- a/applications/ffmpeg_multifile-convert-video.sh
+++ b/applications/ffmpeg_multifile-convert-video.sh
@@ -155,7 +155,7 @@ if [ "$MODE" = "images2video" ]; then
 			--inputbox="Enter the frame rate of the output video file (for 10 selected image files to 1 fps ~1800)" 1800)
 	if-cancel-exit
 	FILENAME=$(kdialog --icon=ks-video --title="Convert Video Files" \
-			--inputbox="Enter filename without whitespaces for new video file" "New images to video")
+			--inputbox="Enter filename without whitespaces for new video file" "New Images to Video")
 	if-cancel-exit
 	DESTINATION=$(kdialog --icon=ks-video --title="Destination Video File" --getexistingdirectory "$DIR" 2>/dev/null)
 	if-cancel-exit

--- a/applications/ffmpeg_multifile-convert-video.sh
+++ b/applications/ffmpeg_multifile-convert-video.sh
@@ -54,6 +54,8 @@ TIMEPOSITION=""
 ############ Functions ############
 ###################################
 
+IFS=$'\n'
+
 logs() {
 	LOG="/tmp/${i##*/}.log"
 	LOGERROR="${i##*/}.err"
@@ -216,6 +218,11 @@ fi
 FILES=$(kdialog --icon=ks-video --title="Source Video Files" --multiple --getopenfilename "$DIR" "*.3GP *.3gp *.AVI *.avi *.DAT *.dat *.DV *.dv *.FLV *.flv *.M2V *.m2v *.M4V *.m4v *.MKV *.mkv \
 		*.MOV *.mov *.MP4 *.mp4 *.MPEG *.mpeg *.MPEG4 *.mpeg4 *.MPG *.mpg *.OGV *.ogv *.VOB *.vob *.WEBM *.webm *.WMV *.wmv|*.3gp *.avi *.dat *.dv *.flv *.m2v *.m4v *.mkv *.mov *.mp4 *.mpeg *.mpeg4 *.mpg *.ogv *.vob *.webm *.wmv" 2>/dev/null)
 if-cancel-exit
+
+FILES=$(echo "$FILES" | sed 's/ (?=\S)/\\ /g')
+FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flv|m2v|m4v|mkv|mov|mp4|mpeg4|mpeg|mpg|ogv|vob|webm|wmv)\s/\.\1\n/gi')
+FILES=$(echo "$FILES" | sed 's/ $//g')
+
 ############################### video2images ###############################
 if [ "$MODE" = "video2images" ]; then
 	IMAGE_FORMAT=$(kdialog --icon=ks-video --title="Convert Video Files" --menu="Choose Image Format" bmp "BMP" jpg "JPG" pam "PAM" pbm "PBM" pgm "PGM" png "PNG" ppm "PPM" sgi "SGI" tif "TIFF" 2>/dev/null)

--- a/applications/ffmpeg_multifile-convert-video.sh
+++ b/applications/ffmpeg_multifile-convert-video.sh
@@ -166,7 +166,7 @@ if [ "$MODE" = "images2video" ]; then
 	ffmpeg -y -f image2 -i /tmp/SequentialImage_%d.${SEQFILE:${#SEQFILE}-3} -r $FRAME_RATE "$DESTINATION/$FILENAME.mp4" &> $LOG
 	if [ "$?" != "0" ]; then
 		kdialog --icon=ks-error --title="Converting sequential images to $FILENAME.mp4" \
-			--passivepopup="[Canceled]   Check the path and filename not contain whitespaces. Check error log $LOGERROR. Try again"
+			--passivepopup="[Canceled]   Check error log $LOGERROR. Try again"
 		mv $LOG $DESTINATION/$LOGERROR
 		continue
 	fi

--- a/applications/ffmpeg_multifile-convert-video.sh
+++ b/applications/ffmpeg_multifile-convert-video.sh
@@ -41,6 +41,7 @@ FILES=""
 FILESIZE=""
 FINAL_TIME=""
 FORMAT="0"
+IFS=$'\n'
 LOG=""
 LOGERROR=""
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:~/bin
@@ -49,8 +50,6 @@ PID="$$"
 RESOLUTION=""
 STD=""
 TIMEPOSITION=""
-
-IFS=$'\n'
 
 ###################################
 ############ Functions ############
@@ -143,16 +142,20 @@ if [ "$MODE" = "images2video" ]; then
 	FILES=$(kdialog --icon=ks-video --title="Select Image Files In Your Preferred Order" --multiple \
 			--getopenfilename "$DIR" "*.bmp *.jpg *.pam *.pbm *.pgm *.png *.ppm *.sgi *.tif *.tiff *.BMP *.JPG *.PAM *.PBM *.PGM *.PNG *.PPM *.SGI *.TIF *.TIFF|*.bmp *.jpg *.pam *.pbm *.pgm *.png *.ppm *.sgi *.tif *.tiff" 2>/dev/null)
 	if-cancel-exit
+	FILES=$(echo "$FILES" | sed -E 's/\.(bmp|jpg|pam|pbm|pgm|png|ppm|sgi|tif|tiff)[[:space:]]+/\.\1\
+	/gI' | sed 's/[[:space:]]*$//')
 
+	COUNT=0
 	for s in $FILES; do
-		cp $s /tmp/SequentialImage_$COUNT.${s:${#s}-3}
+		cp $s /tmp/SequentialImage_${COUNT}.${s##*.}
+		COUNT=$((COUNT+1))
 	done
 
 	FRAME_RATE=$(kdialog --icon=ks-video --title="Convert Video Files|$(ls /tmp/SequentialImage_*|wc -w|sed -e 's/^ *//') selected images" \
 			--inputbox="Enter the frame rate of the output video file (for 10 selected image files to 1 fps ~1800)" 1800)
 	if-cancel-exit
 	FILENAME=$(kdialog --icon=ks-video --title="Convert Video Files" \
-			--inputbox="Enter filename without whitespaces for new video file" New_Video_File)
+			--inputbox="Enter filename without whitespaces for new video file" "New images to video")
 	if-cancel-exit
 	DESTINATION=$(kdialog --icon=ks-video --title="Destination Video File" --getexistingdirectory "$DIR" 2>/dev/null)
 	if-cancel-exit
@@ -162,11 +165,11 @@ if [ "$MODE" = "images2video" ]; then
 	LOGERROR="$FILENAME.err"
 	rm -f $LOGERROR
 	BEGIN_TIME=$(date +%s)
-	SEQFILE=$(ls /tmp/SequentialImage_1.*)
-	ffmpeg -y -f image2 -i /tmp/SequentialImage_%d.${SEQFILE:${#SEQFILE}-3} -r $FRAME_RATE "$DESTINATION/$FILENAME.mp4" &> $LOG
+	SEQFILE=$(ls /tmp/SequentialImage_0.*)
+	ffmpeg -y -f image2 -i /tmp/SequentialImage_%d.${SEQFILE##*.} -r $FRAME_RATE "$DESTINATION/$FILENAME.mp4" &> $LOG
 	if [ "$?" != "0" ]; then
 		kdialog --icon=ks-error --title="Converting sequential images to $FILENAME.mp4" \
-			--passivepopup="[Canceled]   Check error log $LOGERROR. Try again"
+			--passivepopup="[Canceled]   Check the path and filename not contain whitespaces. Check error log $LOGERROR. Try again"
 		mv $LOG $DESTINATION/$LOGERROR
 		continue
 	fi
@@ -190,9 +193,15 @@ if [ "$MODE" = "multiplexaudio" ]; then
 			*.dat *.DV *.dv *.FLV *.flv *.M2V *.m2v *.M4V *.m4v *.MKV *.mkv *.MOV *.mov *.MP4 *.mp4 *.MPEG *.mpeg *.MPEG4 *.mpeg4 *.MPG *.mpg *.OGV *.ogv *.VOB *.vob *.WEBM *.webm \
 			*.WMV *.wmv|*.3gp *.avi *.dat *.dv *.flv *.m2v *.m4v *.mkv *.mov *.mp4 *.mpeg *.mpeg4 *.mpg *.ogv *.vob *.webm *.wmv" 2>/dev/null)
 	if-cancel-exit
+	FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flv|m2v|m4v|mkv|mov|mp4|mpeg4|mpeg|mpg|ogv|vob|webm|wmv)[[:space:]]+/\.\1\
+	/gI' | sed 's/[[:space:]]*$//')
+
 	AUDIO_FILE=$(kdialog --icon=ks-video --title="Select Audio File" \
 			--getopenfilename "$DIR" "*.FLAC *.flac *.M4A *.m4a *.MP2 *.mp2 *.MP3 *.mp3 *.OGG *.ogg *.WAV *.wav *.WMA *.wma|*.flac *.m4a *.mp2 *.mp3 *.ogg *.wav *.wma" 2>/dev/null)
 	if-cancel-exit
+	AUDIO_FILE=$(echo "$AUDIO_FILE" | sed -E 's/\.(flac|m4a|mp2|mp3|ogg|wav|wma)[[:space:]]+/\.\1\
+	/gI' | sed 's/[[:space:]]*$//')
+
 	DESTINATION=$(kdialog --icon=ks-video --title="Destination Video File" --getexistingdirectory "$DIR" 2>/dev/null)
 	if-cancel-exit
 
@@ -206,7 +215,7 @@ if [ "$MODE" = "multiplexaudio" ]; then
 		logs
 		BEGIN_TIME=$(date +%s)
 		DST_FILE="${i%.*}"
-		ffmpeg -y -i $i -i $AUDIO_FILE -c copy -trellis 1 -g 12 "$DESTINATION/${DST_FILE##*/}_AudioMultiplexed.mp4" &> $LOG
+		ffmpeg -y -i $i -i $AUDIO_FILE -c copy -trellis 1 -g 12 "$DESTINATION/${DST_FILE##*/} (ma).mp4" &> $LOG
 		if-ffmpeg-cancel
 		FINAL_TIME=$(date +%s)
 		ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -219,7 +228,8 @@ FILES=$(kdialog --icon=ks-video --title="Source Video Files" --multiple --getope
 		*.MOV *.mov *.MP4 *.mp4 *.MPEG *.mpeg *.MPEG4 *.mpeg4 *.MPG *.mpg *.OGV *.ogv *.VOB *.vob *.WEBM *.webm *.WMV *.wmv|*.3gp *.avi *.dat *.dv *.flv *.m2v *.m4v *.mkv *.mov *.mp4 *.mpeg *.mpeg4 *.mpg *.ogv *.vob *.webm *.wmv" 2>/dev/null)
 if-cancel-exit
 
-FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flv|m2v|m4v|mkv|mov|mp4|mpeg4|mpeg|mpg|ogv|vob|webm|wmv)\s/\.\1\n/gi' | sed 's/ $//g')
+FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flv|m2v|m4v|mkv|mov|mp4|mpeg4|mpeg|mpg|ogv|vob|webm|wmv)[[:space:]]+/\.\1\
+	/gI' | sed 's/[[:space:]]*$//')
 
 ############################### video2images ###############################
 if [ "$MODE" = "video2images" ]; then
@@ -236,7 +246,7 @@ if [ "$MODE" = "video2images" ]; then
 		logs
 		BEGIN_TIME=$(date +%s)
 		DST_FILE="${i%.*}"
-		ffmpeg -y -i $i -r $FRAME_RATE "$DESTINATION/${DST_FILE##*/}_%d.$IMAGE_FORMAT" &> $LOG
+		ffmpeg -y -i $i -r $FRAME_RATE "$DESTINATION/${DST_FILE##*/} %d.$IMAGE_FORMAT" &> $LOG
 		if-ffmpeg-cancel
 		FINAL_TIME=$(date +%s)
 		ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -279,7 +289,7 @@ if [ "$MODE" = "mobile" ]; then
 		BEGIN_TIME=$(date +%s)
 		DST_FILE="${i%.*}"
 		ffmpeg -y -i $i -q:v 0 -mbd 2 -s $RESOLUTION -strict experimental -c:a aac -c:v mpeg4 -b:v 1000k -c:s copy -trellis 1 -g 12 \
-			"$DESTINATION/${DST_FILE##*/}_$RESOLUTION.3gp" &> $LOG
+			"$DESTINATION/${DST_FILE##*/} ($RESOLUTION).3gp" &> $LOG
 		if-ffmpeg-cancel
 		FINAL_TIME=$(date +%s)
 		ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -300,7 +310,7 @@ if [ "$MODE" = "4K" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s 4095x2160 -c:a libmp3lame -b:a 320k -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_Ultra-HD_4K.mpg" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (Ultra-HD 4K).mpg" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -311,7 +321,7 @@ if [ "$MODE" = "4K" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -c:v libx264 -q:v 0 -mbd 2 -s 4k -c:a copy -c:s copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_H.264_Ultra-HD_4K.mp4" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (H.264 Ultra-HD 4K).mp4" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -322,7 +332,7 @@ if [ "$MODE" = "4K" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -c:v libx265 -q:v 0 -crf 23 -mbd 2 -s 4k -c:a copy -c:s copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_H.265_Ultra-HD_4K.mp4" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (H.265 Ultra-HD 4K).mp4" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -333,7 +343,7 @@ if [ "$MODE" = "4K" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s 4k -c:a copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_Ultra-HD_4K.avi" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (Ultra-HD 4K).avi" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -344,7 +354,7 @@ if [ "$MODE" = "4K" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s 4k -c:v libvpx -b:v 1000k -c:a libvorbis -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_Ultra-HD_4K.webm" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (Ultra-HD 4K).webm" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -366,7 +376,7 @@ if [ "$MODE" = "2K" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s 2k -c:a libmp3lame -b:a 320k -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_DCI_2K.mpg" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (DCI 2K).mpg" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -377,7 +387,7 @@ if [ "$MODE" = "2K" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -c:v libx264 -q:v 0 -mbd 2 -s 2k -c:a copy -c:s copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_H.264_DCI_2K.mp4" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (H.264 DCI 2K).mp4" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -388,7 +398,7 @@ if [ "$MODE" = "2K" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -c:v libx265 -q:v 0 -crf 23 -mbd 2 -s 2k -c:a copy -c:s copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_H.265_DCI_2K.mp4" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (H.265 DCI 2K).mp4" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -399,7 +409,7 @@ if [ "$MODE" = "2K" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s 2k -c:a copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_DCI_2K.avi" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (DCI 2K).avi" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -410,7 +420,7 @@ if [ "$MODE" = "2K" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s 2k -c:v libvpx -b:v 1000k -c:a libvorbis -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_DCI_2K.webm" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (DCI 2K).webm" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -432,7 +442,7 @@ if [ "$MODE" = "1080" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s hd1080 -c:a libmp3lame -b:a 320k -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_Full-HD_1080p.mpg" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (Full-HD 1080p).mpg" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -443,7 +453,7 @@ if [ "$MODE" = "1080" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -c:v libx264 -q:v 0 -mbd 2 -s hd1080 -c:a copy -c:s copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_H.264_Full-HD_1080p.mp4" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (H.264 Full-HD 1080p).mp4" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -454,7 +464,7 @@ if [ "$MODE" = "1080" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -c:v libx265 -q:v 0 -crf 23 -mbd 2 -s hd1080 -c:a copy -c:s copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_H.265_Full-HD_1080p.mp4" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (H.265 Full-HD 1080p).mp4" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -465,7 +475,7 @@ if [ "$MODE" = "1080" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s hd1080 -c:a copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_Full-HD_1080p.avi" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (Full-HD 1080p).avi" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -476,7 +486,7 @@ if [ "$MODE" = "1080" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s hd1080 -c:v libvpx -b:v 1000k -c:a libvorbis -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_Full-HD_1080p.webm" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (Full-HD 1080p).webm" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -498,7 +508,7 @@ if [ "$MODE" = "720" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s hd720 -c:a libmp3lame -b:a 320k -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_HD_720p.mpg" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (HD 720p).mpg" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -509,7 +519,7 @@ if [ "$MODE" = "720" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -c:v libx264 -q:v 0 -mbd 2 -s hd720 -c:a copy -c:s copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_H.264_HD_720p.mp4" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (H.264 HD 720p).mp4" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -520,7 +530,7 @@ if [ "$MODE" = "720" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -c:v libx265 -q:v 0 -crf 23 -mbd 2 -s hd720 -c:a copy -c:s copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_H.265_HD_720p.mp4" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (H.265 HD 720p).mp4" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -531,7 +541,7 @@ if [ "$MODE" = "720" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s hd720 -c:a copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_HD_720p.avi" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (HD 720p).avi" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -542,7 +552,7 @@ if [ "$MODE" = "720" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s hd720 -c:v libvpx -b:v 1000k -c:a libvorbis -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_HD_720p.webm" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (HD 720p).webm" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -564,7 +574,7 @@ if [ "$MODE" = "480" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s hd480 -c:a libmp3lame -b:a 320k -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_ED_480p.mpg" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (ED 480p).mpg" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -575,7 +585,7 @@ if [ "$MODE" = "480" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -c:v libx264 -q:v 0 -mbd 2 -s hd480 -c:a copy -c:s copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_H.264_ED_480p.mp4" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (H.264 ED 480p).mp4" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -586,7 +596,7 @@ if [ "$MODE" = "480" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -c:v libx265 -q:v 0 -crf 23 -mbd 2 -s hd480 -c:a copy -c:s copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_H.265_ED_480p.mp4" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (H.265 ED 480p).mp4" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -597,7 +607,7 @@ if [ "$MODE" = "480" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s hd480 -c:a copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_ED_480p.avi" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (ED 480p).avi" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -608,7 +618,7 @@ if [ "$MODE" = "480" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s hd480 -c:v libvpx -b:v 1000k -c:a libvorbis -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_ED_480p.webm" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (ED 480p).webm" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -630,7 +640,7 @@ if [ "$MODE" = "360" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s nhd -c:a libmp3lame -b:a 320k -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_NHD_360p.mpg" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (NHD 360p).mpg" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -641,7 +651,7 @@ if [ "$MODE" = "360" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -c:v libx264 -q:v 0 -mbd 2 -s nhd -c:a copy -c:s copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_H.264_NHD_360p.mp4" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (H.264 NHD 360p).mp4" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -652,7 +662,7 @@ if [ "$MODE" = "360" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -c:v libx265 -q:v 0 -crf 23 -mbd 2 -s nhd -c:a copy -c:s copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_H.265_NHD_360p.mp4" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (H.265 NHD 360p).mp4" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -663,7 +673,7 @@ if [ "$MODE" = "360" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s nhd -c:a copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_NHD_360p.avi" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (NHD 360p).avi" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -674,7 +684,7 @@ if [ "$MODE" = "360" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s nhd -c:v libvpx -b:v 1000k -c:a libvorbis -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_NHD_360p.webm" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (NHD 360p).webm" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -696,7 +706,7 @@ if [ "$MODE" = "240" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s qvga -c:a libmp3lame -b:a 320k -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_240p.mpg" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (240p).mpg" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -707,7 +717,7 @@ if [ "$MODE" = "240" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -c:v libx264 -q:v 0 -mbd 2 -s qvga -c:a copy -c:s copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_H.264_240p.mp4" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (H.264 240p).mp4" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -718,7 +728,7 @@ if [ "$MODE" = "240" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -c:v libx265 -q:v 0 -crf 23 -mbd 2 -s qvga -c:a copy -c:s copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_H.265_240p.mp4" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (H.265 240p).mp4" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -729,7 +739,7 @@ if [ "$MODE" = "240" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s qvga -c:a copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_240p.avi" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (240p).avi" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -740,7 +750,7 @@ if [ "$MODE" = "240" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s qvga -c:v libvpx -b:v 1000k -c:a libvorbis -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_240p.webm" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (240p).webm" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -762,7 +772,7 @@ if [ "$MODE" = "same" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -c:a libmp3lame -b:a 320k -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_sr.mpg" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (sr).mpg" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -773,7 +783,7 @@ if [ "$MODE" = "same" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -c:v libx264 -q:v 0 -mbd 2 -c:a copy -c:s copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_H.264_sr.mp4" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (H.264 sr).mp4" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -784,7 +794,7 @@ if [ "$MODE" = "same" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -c:v libx265 -q:v 0 -crf 23 -mbd 2 -c:a copy -c:s copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_H.265_sr.mp4" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (H.265 sr).mp4" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -795,7 +805,7 @@ if [ "$MODE" = "same" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -c:a copy -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_sr.avi" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (sr).avi" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -806,7 +816,7 @@ if [ "$MODE" = "same" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -c:v flv -b:v 1000k -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_sr.flv" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (sr).flv" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -817,7 +827,7 @@ if [ "$MODE" = "same" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -c:v libvpx -b:v 1000k -c:a libvorbis -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_sr.webm" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (sr).webm" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -828,7 +838,7 @@ if [ "$MODE" = "same" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -c:v mpeg2video -c:a libmp3lame -b:a 320k -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_sr.mpg" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} (sr).mpg" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -897,7 +907,7 @@ if [ "$MODE" = "standards" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -target $FORMAT -mbd 2 -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_$FORMAT.mpg" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} ($FORMAT).mpg" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -908,7 +918,7 @@ if [ "$MODE" = "standards" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -target $FORMAT -ss $TIMEPOSITION -fs $FILESIZE -mbd 2 -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_$FORMAT.mpg" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} ($FORMAT).mpg" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -919,7 +929,7 @@ if [ "$MODE" = "standards" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -target $FORMAT -mbd 2 -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_$FORMAT.mpg" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} ($FORMAT).mpg" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -930,7 +940,7 @@ if [ "$MODE" = "standards" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -target $FORMAT -ss $TIMEPOSITION -fs $FILESIZE -mbd 2 -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_$FORMAT.mpg" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} ($FORMAT).mpg" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -941,7 +951,7 @@ if [ "$MODE" = "standards" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -target $FORMAT -mbd 2 -trellis 1 -g 12 -ac 6 \
-				"$DESTINATION/${DST_FILE##*/}_$FORMAT.mpg" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} ($FORMAT).mpg" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -952,7 +962,7 @@ if [ "$MODE" = "standards" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -target $FORMAT -ss $TIMEPOSITION -fs $FILESIZE -mbd 2 -trellis 1 -g 12 -ac 6 \
-				"$DESTINATION/${DST_FILE##*/}_$FORMAT.mpg" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} ($FORMAT).mpg" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -963,7 +973,7 @@ if [ "$MODE" = "standards" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -target $FORMAT -ss $TIMEPOSITION -fs $FILESIZE -mbd 2 -trellis 1 -g 12 -ac 6 \
-				"$DESTINATION/${DST_FILE##*/}_$FORMAT.mpg" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} ($FORMAT).mpg" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -986,7 +996,7 @@ if [ "$MODE" = "web" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s $RESOLUTION -c:v flv -b:v 1000k -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_$RESOLUTION.flv" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} ($RESOLUTION).flv" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -1001,7 +1011,7 @@ if [ "$MODE" = "web" ]; then
 			BEGIN_TIME=$(date +%s)
 			DST_FILE="${i%.*}"
 			ffmpeg -y -i $i -q:v 0 -mbd 2 -s $RESOLUTION -c:v libvpx -b:v 1000k -c:a libvorbis -trellis 1 -g 12 \
-				"$DESTINATION/${DST_FILE##*/}_$RESOLUTION.webm" &> $LOG
+				"$DESTINATION/${DST_FILE##*/} ($RESOLUTION).webm" &> $LOG
 			if-ffmpeg-cancel
 			FINAL_TIME=$(date +%s)
 			ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -1030,7 +1040,7 @@ if [ "$MODE" = "customized" ]; then
 		BEGIN_TIME=$(date +%s)
 		DST_FILE="${i%.*}"
 		ffmpeg -y -i $i -q:v 0 -mbd 2 -s $RESOLUTION -c:v $VIDEO_CODEC -c:a $AUDIO_CODEC -b:a ${AUDIO_BITRATE}k -trellis 1 -g 12 \
-			"$DESTINATION/${DST_FILE##*/}_[${RESOLUTION}_${VIDEO_CODEC}_${AUDIO_CODEC}].mkv" &> $LOG
+			"$DESTINATION/${DST_FILE##*/} (${RESOLUTION} ${VIDEO_CODEC} ${AUDIO_CODEC}).mkv" &> $LOG
 		if-ffmpeg-cancel
 		FINAL_TIME=$(date +%s)
 		ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))

--- a/applications/ffmpeg_multifile-convert-video.sh
+++ b/applications/ffmpeg_multifile-convert-video.sh
@@ -219,9 +219,7 @@ FILES=$(kdialog --icon=ks-video --title="Source Video Files" --multiple --getope
 		*.MOV *.mov *.MP4 *.mp4 *.MPEG *.mpeg *.MPEG4 *.mpeg4 *.MPG *.mpg *.OGV *.ogv *.VOB *.vob *.WEBM *.webm *.WMV *.wmv|*.3gp *.avi *.dat *.dv *.flv *.m2v *.m4v *.mkv *.mov *.mp4 *.mpeg *.mpeg4 *.mpg *.ogv *.vob *.webm *.wmv" 2>/dev/null)
 if-cancel-exit
 
-FILES=$(echo "$FILES" | sed 's/ (?=\S)/\\ /g')
 FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flv|m2v|m4v|mkv|mov|mp4|mpeg4|mpeg|mpg|ogv|vob|webm|wmv)\s/\.\1\n/gi')
-FILES=$(echo "$FILES" | sed 's/ $//g')
 
 ############################### video2images ###############################
 if [ "$MODE" = "video2images" ]; then

--- a/applications/ffmpeg_multifile-convert-video.sh
+++ b/applications/ffmpeg_multifile-convert-video.sh
@@ -50,11 +50,11 @@ RESOLUTION=""
 STD=""
 TIMEPOSITION=""
 
+IFS=$'\n'
+
 ###################################
 ############ Functions ############
 ###################################
-
-IFS=$'\n'
 
 logs() {
 	LOG="/tmp/${i##*/}.log"
@@ -81,7 +81,7 @@ if-cancel-exit() {
 if-ffmpeg-cancel() {
 	if [ "$?" != "0" ]; then
 		kdialog --icon=ks-error --title="Converting video ${i##*/}" \
-			--passivepopup="[Canceled]   Check the path and filename not contain whitespaces. Check error log $LOGERROR. Try again"
+			--passivepopup="[Canceled]   Check error log $LOGERROR. Try again"
 		mv $LOG $DESTINATION/$LOGERROR
 		continue
 	fi
@@ -219,7 +219,7 @@ FILES=$(kdialog --icon=ks-video --title="Source Video Files" --multiple --getope
 		*.MOV *.mov *.MP4 *.mp4 *.MPEG *.mpeg *.MPEG4 *.mpeg4 *.MPG *.mpg *.OGV *.ogv *.VOB *.vob *.WEBM *.webm *.WMV *.wmv|*.3gp *.avi *.dat *.dv *.flv *.m2v *.m4v *.mkv *.mov *.mp4 *.mpeg *.mpeg4 *.mpg *.ogv *.vob *.webm *.wmv" 2>/dev/null)
 if-cancel-exit
 
-FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flv|m2v|m4v|mkv|mov|mp4|mpeg4|mpeg|mpg|ogv|vob|webm|wmv)\s/\.\1\n/gi')
+FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flv|m2v|m4v|mkv|mov|mp4|mpeg4|mpeg|mpg|ogv|vob|webm|wmv)\s/\.\1\n/gi' | sed 's/ $//g')
 
 ############################### video2images ###############################
 if [ "$MODE" = "video2images" ]; then

--- a/applications/ffmpeg_multifile-edit-media-time.sh
+++ b/applications/ffmpeg_multifile-edit-media-time.sh
@@ -67,7 +67,7 @@ if-cancel-exit() {
 if-ffmpeg-cancel() {
 	if [ "$?" != "0" ]; then
 		kdialog --icon=ks-error --title="Editing time of ${i##*/} from $STIME to $ETIME" \
-			--passivepopup="[Canceled]   Check the path and filename not contain whitespaces. Check error log $LOGERROR. Try again"
+			--passivepopup="[Canceled]   Check error log $LOGERROR. Try again"
 		mv $LOG $DESTINATION/$LOGERROR
 		continue
 	fi
@@ -110,10 +110,14 @@ if [ "$DIR" == "~/.local/share/applications" ]; then
 	DIR="~/"
 fi
 
+IFS=$'\n'
+
 FILES=$(kdialog --icon=ks-media-edit-time --title="Edit Time from Media Files" --multiple --getopenfilename "$DIR" "*.3GP *.3gp *.AVI *.avi *.DAT \
 		*.dat *.DV *.dv *.FLAC *.flac *.FLV *.flv *.M2V *.m2v *.M4A *.m4a *.M4V *.m4v *.MKV *.mkv *.MOV *.mov *.MP3 *.mp3 *.MP4 *.mp4 *.MPEG *.mpeg *.MPEG4 *.mpeg4 *.MPG *.mpg *.OGG *.ogg *.OGV *.ogv \
 		*.VOB *.vob *.WAV *.wav *.WEBM *.webm *.WMA *.wma *.WMV *.wmv|*.3gp *.avi *.dat *.dv *.flac *.flv *.m2v *.m4a *.m4v *.mkv *.mov *.mp3 *.mp4 *.mpeg *.mpeg4 *.mpg *.ogg *.ogv *.vob *.wav *.webm *.wma *.wmv" 2>/dev/null)
 if-cancel-exit
+
+FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flac|flv|m2v|m4a|m4v|mkv|mov|mp3|mp4|mpeg|mpeg4|mpg|ogg|ogv|vob|wav|webm|wma|wmv)\s/\.\1\n/gi' | sed 's/ $//g')
 
 DESTINATION=$(kdialog --icon=ks-media-edit-time --title="Destination Video Files" --getexistingdirectory "$DIR" 2>/dev/null)
 if-cancel-exit

--- a/applications/ffmpeg_multifile-edit-media-time.sh
+++ b/applications/ffmpeg_multifile-edit-media-time.sh
@@ -38,6 +38,7 @@ DIR=""
 ELAPSED_TIME=""
 ETIME=""
 FINAL_TIME=""
+IFS=$'\n'
 LOG=""
 LOGERROR=""
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:~/bin
@@ -110,14 +111,13 @@ if [ "$DIR" == "~/.local/share/applications" ]; then
 	DIR="~/"
 fi
 
-IFS=$'\n'
-
 FILES=$(kdialog --icon=ks-media-edit-time --title="Edit Time from Media Files" --multiple --getopenfilename "$DIR" "*.3GP *.3gp *.AVI *.avi *.DAT \
 		*.dat *.DV *.dv *.FLAC *.flac *.FLV *.flv *.M2V *.m2v *.M4A *.m4a *.M4V *.m4v *.MKV *.mkv *.MOV *.mov *.MP3 *.mp3 *.MP4 *.mp4 *.MPEG *.mpeg *.MPEG4 *.mpeg4 *.MPG *.mpg *.OGG *.ogg *.OGV *.ogv \
 		*.VOB *.vob *.WAV *.wav *.WEBM *.webm *.WMA *.wma *.WMV *.wmv|*.3gp *.avi *.dat *.dv *.flac *.flv *.m2v *.m4a *.m4v *.mkv *.mov *.mp3 *.mp4 *.mpeg *.mpeg4 *.mpg *.ogg *.ogv *.vob *.wav *.webm *.wma *.wmv" 2>/dev/null)
 if-cancel-exit
 
-FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flac|flv|m2v|m4a|m4v|mkv|mov|mp3|mp4|mpeg|mpeg4|mpg|ogg|ogv|vob|wav|webm|wma|wmv)\s/\.\1\n/gi' | sed 's/ $//g')
+FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flac|flv|m2v|m4a|m4v|mkv|mov|mp3|mp4|mpeg|mpeg4|mpg|ogg|ogv|vob|wav|webm|wma|wmv)[[:space:]]+/\.\1\
+/gI' | sed 's/[[:space:]]*$//')
 
 DESTINATION=$(kdialog --icon=ks-media-edit-time --title="Destination Video Files" --getexistingdirectory "$DIR" 2>/dev/null)
 if-cancel-exit
@@ -135,7 +135,7 @@ for i in $FILES; do
 	logs
 	BEGIN_TIME=$(date +%s)
 	DST_FILE="${i%.*}"
-	ffmpeg -y -i $i -ss $STIME -to $ETIME -c copy "$DESTINATION/${DST_FILE##*/}_Time-$STIME-$ETIME-Edited.${i:${#i}-3}" &> $LOG
+	ffmpeg -y -i $i -ss $STIME -to $ETIME -c copy "$DESTINATION/${DST_FILE##*/} (Time $STIME-$ETIME Edited).${i##*.}" &> $LOG
 	if-ffmpeg-cancel
 	FINAL_TIME=$(date +%s)
 	ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))

--- a/applications/ffmpeg_multifile-extract-audio.sh
+++ b/applications/ffmpeg_multifile-extract-audio.sh
@@ -38,6 +38,7 @@ DIR=""
 ELAPSED_TIME=""
 FINAL_TIME=""
 FORMAT=""
+IFS=$'\n'
 LOG=""
 LOGERROR=""
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:~/bin
@@ -127,14 +128,13 @@ if [ "$DIR" == "~/.local/share/applications" ]; then
 	DIR="~/"
 fi
 
-IFS=$'\n'
-
 FILES=$(kdialog --icon=ks-audio --title="Video|Audio Files" --multiple --getopenfilename "$DIR" "*.3GP *.3gp *.AVI *.avi *.DAT *.dat *.DV *.dv \
 		*.FLAC *.flac *.FLV *.flv *.M2V *.m2v *.M4A *.m4a *.M4V *.m4v *.MKV *.mkv *.MOV *.mov *.MP3 *.mp3 *.MP4 *.mp4 *.MPEG *.mpeg *.MPEG4 *.mpeg4 *.MPG *.mpg *.OGG *.ogg *.OGV *.ogv *.VOB *.vob *.WAV *.wav \
 		*.WEBM *.webm *.WMA *.wma *.WMV *.wmv|*.3gp *.avi *.dat *.dv *.flac *.flv *.m2v *.m4a *.m4v *.mkv *.mov *.mp3 *.mp4 *.mpeg *.mpeg4 *.mpg *.ogg *.ogv *.vob *.wav *.webm *.wma *.wmv" 2>/dev/null)
 if-cancel-exit
 
-FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flac|flv|m2v|m4a|m4v|mkv|mov|mp3|mp4|mpeg|mpeg4|mpg|ogg|ogv|vob|wav|webm|wma|wmv)\s/\.\1\n/gi' | sed 's/ $//g')
+FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flac|flv|m2v|m4a|m4v|mkv|mov|mp3|mp4|mpeg|mpeg4|mpg|ogg|ogv|vob|wav|webm|wma|wmv)[[:space:]]+/\.\1\
+/gI' | sed 's/[[:space:]]*$//')
 
 FORMAT=$(kdialog --icon=ks-audio --title="Extract|Convert Audio Track" \
 		--combobox="Choose Audio Encoder" FLAC "FLAC (432Hz)" MP3 "MP3 (432Hz)" OGG "OGG (432Hz)" --default "MP3 (432Hz)" 2>/dev/null)
@@ -157,9 +157,9 @@ if [ "$FORMAT" = "MP3 (432Hz)" ]; then
 		if-ffmpeg-cancel
 		sox "/tmp/${DST_FILE##*/}_$MODE.wav" "/tmp/${DST_FILE##*/}_${MODE}_432Hz.wav" pitch -31 &> $LOG
 		if-sox-cancel
-		ffmpeg -y -i "/tmp/${DST_FILE##*/}_${MODE}_432Hz.wav" -c:a libmp3lame -b:a $MODE "$DESTINATION/${DST_FILE##*/}_${MODE}_432Hz.mp3" &> $LOG
+		ffmpeg -y -i "/tmp/${DST_FILE##*/}_${MODE}_432Hz.wav" -c:a libmp3lame -b:a $MODE "$DESTINATION/${DST_FILE##*/} (${MODE} 432Hz).mp3" &> $LOG
 		if-ffmpeg-cancel
-		mp3gain -c -r "$DESTINATION/${DST_FILE##*/}_${MODE}_432Hz.mp3" &> $LOG
+		mp3gain -c -r "$DESTINATION/${DST_FILE##*/} (${MODE} 432Hz).mp3" &> $LOG
 		if-mp3gain-cancel
 		rm -f /tmp/${DST_FILE##*/}_${MODE}*.wav
 		FINAL_TIME=$(date +%s)
@@ -176,9 +176,9 @@ elif [ "$FORMAT" = "MP3" ]; then
 		logs
 		BEGIN_TIME=$(date +%s)
 		DST_FILE="${i%.*}"
-		ffmpeg -y -i $i -c:a libmp3lame -b:a $MODE "$DESTINATION/${DST_FILE##*/}_$MODE.mp3" &> $LOG
+		ffmpeg -y -i $i -c:a libmp3lame -b:a $MODE "$DESTINATION/${DST_FILE##*/} ($MODE).mp3" &> $LOG
 		if-ffmpeg-cancel
-		mp3gain -c -r "$DESTINATION/${DST_FILE##*/}_$MODE.mp3" &> $LOG
+		mp3gain -c -r "$DESTINATION/${DST_FILE##*/} ($MODE).mp3" &> $LOG
 		if-mp3gain-cancel
 		FINAL_TIME=$(date +%s)
 		ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -195,7 +195,7 @@ elif [ "$FORMAT" = "FLAC (432Hz)" ]; then
 		if-ffmpeg-cancel
 		sox "/tmp/${DST_FILE##*/}.wav" "/tmp/${DST_FILE##*/}_432Hz.wav" pitch -31 &> $LOG
 		if-sox-cancel
-		ffmpeg -y -i "/tmp/${DST_FILE##*/}_432Hz.wav" -c:a flac "$DESTINATION/${DST_FILE##*/}_432Hz.flac" &> $LOG
+		ffmpeg -y -i "/tmp/${DST_FILE##*/}_432Hz.wav" -c:a flac "$DESTINATION/${DST_FILE##*/} (432Hz).flac" &> $LOG
 		if-ffmpeg-cancel
 		rm -f /tmp/${DST_FILE##*/}*.wav
 		FINAL_TIME=$(date +%s)
@@ -226,7 +226,7 @@ elif [ "$FORMAT" = "OGG (432Hz)" ]; then
 		if-ffmpeg-cancel
 		sox "/tmp/${DST_FILE##*/}.wav" "/tmp/${DST_FILE##*/}_432Hz.wav" pitch -31 &> $LOG
 		if-sox-cancel
-		ffmpeg -y -i "/tmp/${DST_FILE##*/}_432Hz.wav" "$DESTINATION/${DST_FILE##*/}_432Hz.ogg" &> $LOG
+		ffmpeg -y -i "/tmp/${DST_FILE##*/}_432Hz.wav" "$DESTINATION/${DST_FILE##*/} (432Hz).ogg" &> $LOG
 		if-ffmpeg-cancel
 		rm -f /tmp/${DST_FILE##*/}*.wav
 		FINAL_TIME=$(date +%s)

--- a/applications/ffmpeg_multifile-extract-audio.sh
+++ b/applications/ffmpeg_multifile-extract-audio.sh
@@ -66,7 +66,7 @@ if-cancel-exit() {
 if-ffmpeg-cancel() {
 	if [ "$?" != "0" ]; then
 		kdialog --icon=ks-error --title="Extracting audio track from ${i##*/} to $FORMAT" \
-			--passivepopup="[Canceled]   Check the path and filename not contain whitespaces. Check error log $LOGERROR. Try again"
+			--passivepopup="[Canceled]   Check error log $LOGERROR. Try again"
 		mv $LOG $DESTINATION/$LOGERROR
 		continue
 	fi
@@ -75,7 +75,7 @@ if-ffmpeg-cancel() {
 if-sox-cancel() {
 	if [ "$?" != "0" ]; then
 		kdialog --icon=ks-error --title="Extracting audio track from ${i##*/} to $FORMAT" \
-			--passivepopup="[Canceled]   Check the path and filename not contain whitespaces. Check error log $LOGERROR. Try again"
+			--passivepopup="[Canceled]   Check error log $LOGERROR. Try again"
 		mv $LOG $DESTINATION/$LOGERROR
 		continue
 	fi
@@ -84,7 +84,7 @@ if-sox-cancel() {
 if-mp3gain-cancel() {
 	if [ "$?" != "0" ]; then
 		kdialog --icon=ks-error --title="Extracting audio track from ${i##*/} to $FORMAT" \
-			--passivepopup="[Canceled]   Check the path and filename not contain whitespaces. Check error log $LOGERROR. Try again"
+			--passivepopup="[Canceled]   Check error log $LOGERROR. Try again"
 		mv $LOG $DESTINATION/$LOGERROR
 		continue
 	fi
@@ -127,10 +127,14 @@ if [ "$DIR" == "~/.local/share/applications" ]; then
 	DIR="~/"
 fi
 
+IFS=$'\n'
+
 FILES=$(kdialog --icon=ks-audio --title="Video|Audio Files" --multiple --getopenfilename "$DIR" "*.3GP *.3gp *.AVI *.avi *.DAT *.dat *.DV *.dv \
 		*.FLAC *.flac *.FLV *.flv *.M2V *.m2v *.M4A *.m4a *.M4V *.m4v *.MKV *.mkv *.MOV *.mov *.MP3 *.mp3 *.MP4 *.mp4 *.MPEG *.mpeg *.MPEG4 *.mpeg4 *.MPG *.mpg *.OGG *.ogg *.OGV *.ogv *.VOB *.vob *.WAV *.wav \
 		*.WEBM *.webm *.WMA *.wma *.WMV *.wmv|*.3gp *.avi *.dat *.dv *.flac *.flv *.m2v *.m4a *.m4v *.mkv *.mov *.mp3 *.mp4 *.mpeg *.mpeg4 *.mpg *.ogg *.ogv *.vob *.wav *.webm *.wma *.wmv" 2>/dev/null)
 if-cancel-exit
+
+FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flac|flv|m2v|m4a|m4v|mkv|mov|mp3|mp4|mpeg|mpeg4|mpg|ogg|ogv|vob|wav|webm|wma|wmv)\s/\.\1\n/gi' | sed 's/ $//g')
 
 FORMAT=$(kdialog --icon=ks-audio --title="Extract|Convert Audio Track" \
 		--combobox="Choose Audio Encoder" FLAC "FLAC (432Hz)" MP3 "MP3 (432Hz)" OGG "OGG (432Hz)" --default "MP3 (432Hz)" 2>/dev/null)

--- a/applications/ffmpeg_multifile-video-rotate.sh
+++ b/applications/ffmpeg_multifile-video-rotate.sh
@@ -38,6 +38,7 @@ DESTINATION=""
 DIR=""
 ELAPSED_TIME=""
 FINAL_TIME=""
+IFS=$'\n'
 LOG=""
 LOGERROR=""
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:~/bin
@@ -109,13 +110,12 @@ if [ "$DIR" == "~/.local/share/applications" ]; then
 	DIR="~/"
 fi
 
-IFS=$'\n'
-
 FILES=$(kdialog --icon=ks-video-rotate --title="Rotate Video Files" --multiple --getopenfilename "$DIR" "*.3GP *.3gp *.AVI *.avi *.DAT *.dat *.DV *.dv *.FLV *.flv *.M2V *.m2v *.M4V *.m4v \
 		*.MKV *.mkv *.MOV *.mov *.MP4 *.mp4 *.MPEG *.mpeg *.MPEG4 *.mpeg4 *.MPG *.mpg *.OGV *.ogv *.VOB *.vob *.WEBM *.webm *.WMV *.wmv|*.3gp *.avi *.dat *.dv *.flv *.m2v *.m4v *.mkv *.mov *.mp4 *.mpeg *.mpeg4 *.mpg *.ogv *.vob *.webm *.wmv" 2>/dev/null)
 if-cancel-exit
 
-FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flv|m2v|m4v|mkv|mov|mp4|mpeg|mpeg4|mpg|ogv|vob|webm|wmv)\s/\.\1\n/gi' | sed 's/ $//g')
+FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flv|m2v|m4v|mkv|mov|mp4|mpeg|mpeg4|mpg|ogv|vob|webm|wmv)[[:space:]]+/\.\1\
+/gI' | sed 's/[[:space:]]*$//')
 
 DESTINATION=$(kdialog --icon=ks-video-rotate --title="Destination Video Files" --getexistingdirectory "$DIR" 2>/dev/null)
 if-cancel-exit
@@ -131,7 +131,7 @@ if [ "$ANGLE" = "90 Clockwise" ]; then
 		logs
 		BEGIN_TIME=$(date +%s)
 		DST_FILE="${i%.*}"
-		ffmpeg -y -i $i -vf "transpose=clock" -c:a copy "$DESTINATION/${DST_FILE##*/}_90-Clockwise.${i:${#i}-3}" &> $LOG
+		ffmpeg -y -i $i -vf "transpose=clock" -c:a copy "$DESTINATION/${DST_FILE##*/} (90 CW).${i##*.}" &> $LOG
 		if-ffmpeg-cancel
 		FINAL_TIME=$(date +%s)
 		ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -144,7 +144,7 @@ elif [ "$ANGLE" = "90 Clockwise and Vertical Flip" ]; then
 		logs
 		BEGIN_TIME=$(date +%s)
 		DST_FILE="${i%.*}"
-		ffmpeg -y -i $i -vf "transpose=clock_flip" -c:a copy "$DESTINATION/${DST_FILE##*/}_90-Clockwise-VFlip.${i:${#i}-3}" &> $LOG
+		ffmpeg -y -i $i -vf "transpose=clock_flip" -c:a copy "$DESTINATION/${DST_FILE##*/} (90 CW-VF).${i##*.}" &> $LOG
 		if-ffmpeg-cancel
 		FINAL_TIME=$(date +%s)
 		ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -157,7 +157,7 @@ elif [ "$ANGLE" = "90 CounterClockwise" ]; then
 		logs
 		BEGIN_TIME=$(date +%s)
 		DST_FILE="${i%.*}"
-		ffmpeg -y -i $i -vf "transpose=cclock" -c:a copy "$DESTINATION/${DST_FILE##*/}_90-CounterClockwise.${i:${#i}-3}" &> $LOG
+		ffmpeg -y -i $i -vf "transpose=cclock" -c:a copy "$DESTINATION/${DST_FILE##*/} (90 CCW).${i##*.}" &> $LOG
 		if-ffmpeg-cancel
 		FINAL_TIME=$(date +%s)
 		ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -170,7 +170,7 @@ elif [ "$ANGLE" = "90 CounterClockwise and Vertical Flip" ]; then
 		logs
 		BEGIN_TIME=$(date +%s)
 		DST_FILE="${i%.*}"
-		ffmpeg -y -i $i -vf "transpose=cclock_flip" -c:a copy "$DESTINATION/${DST_FILE##*/}_90-CounterClockwise-VFlip.${i:${#i}-3}" &> $LOG
+		ffmpeg -y -i $i -vf "transpose=cclock_flip" -c:a copy "$DESTINATION/${DST_FILE##*/} (90 CCW-VF).${i##*.}" &> $LOG
 		if-ffmpeg-cancel
 		FINAL_TIME=$(date +%s)
 		ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -183,7 +183,7 @@ elif [ "$ANGLE" = "180 Clockwise" ]; then
 		logs
 		BEGIN_TIME=$(date +%s)
 		DST_FILE="${i%.*}"
-		ffmpeg -y -i $i -vf "transpose=clock,transpose=clock" -c:a copy "$DESTINATION/${DST_FILE##*/}_180-Clockwise.${i:${#i}-3}" &> $LOG
+		ffmpeg -y -i $i -vf "transpose=clock,transpose=clock" -c:a copy "$DESTINATION/${DST_FILE##*/} (180 CW).${i##*.}" &> $LOG
 		if-ffmpeg-cancel
 		FINAL_TIME=$(date +%s)
 		ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -196,7 +196,7 @@ elif [ "$ANGLE" = "Horizontal Mirror" ]; then
 		logs
 		BEGIN_TIME=$(date +%s)
 		DST_FILE="${i%.*}"
-		ffmpeg -y -i $i -vf "transpose=clock,transpose=clock_flip" -c:a copy "$DESTINATION/${DST_FILE##*/}_HMirror.${i:${#i}-3}" &> $LOG
+		ffmpeg -y -i $i -vf "transpose=clock,transpose=clock_flip" -c:a copy "$DESTINATION/${DST_FILE##*/} (HM).${i##*.}" &> $LOG
 		if-ffmpeg-cancel
 		FINAL_TIME=$(date +%s)
 		ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))
@@ -209,7 +209,7 @@ elif [ "$ANGLE" = "Vertical Mirror" ]; then
 		logs
 		BEGIN_TIME=$(date +%s)
 		DST_FILE="${i%.*}"
-		ffmpeg -y -i $i -vf "transpose=clock_flip,transpose=clock" -c:a copy "$DESTINATION/${DST_FILE##*/}_VMirror.${i:${#i}-3}" &> $LOG
+		ffmpeg -y -i $i -vf "transpose=clock_flip,transpose=clock" -c:a copy "$DESTINATION/${DST_FILE##*/} (VM).${i##*.}" &> $LOG
 		if-ffmpeg-cancel
 		FINAL_TIME=$(date +%s)
 		ELAPSED_TIME=$((FINAL_TIME-BEGIN_TIME))

--- a/applications/ffmpeg_multifile-video-rotate.sh
+++ b/applications/ffmpeg_multifile-video-rotate.sh
@@ -66,7 +66,7 @@ if-cancel-exit() {
 if-ffmpeg-cancel() {
 	if [ "$?" != "0" ]; then
 		kdialog --icon=ks-error --title="Rotating video file ${i##*/} to $ANGLE" \
-			--passivepopup="[Canceled]   Check the path and filename not contain whitespaces. Check error log $LOGERROR. Try again"
+			--passivepopup="[Canceled]   Check error log $LOGERROR. Try again"
 		mv $LOG $DESTINATION/$LOGERROR
 		continue
 	fi
@@ -109,9 +109,13 @@ if [ "$DIR" == "~/.local/share/applications" ]; then
 	DIR="~/"
 fi
 
+IFS=$'\n'
+
 FILES=$(kdialog --icon=ks-video-rotate --title="Rotate Video Files" --multiple --getopenfilename "$DIR" "*.3GP *.3gp *.AVI *.avi *.DAT *.dat *.DV *.dv *.FLV *.flv *.M2V *.m2v *.M4V *.m4v \
 		*.MKV *.mkv *.MOV *.mov *.MP4 *.mp4 *.MPEG *.mpeg *.MPEG4 *.mpeg4 *.MPG *.mpg *.OGV *.ogv *.VOB *.vob *.WEBM *.webm *.WMV *.wmv|*.3gp *.avi *.dat *.dv *.flv *.m2v *.m4v *.mkv *.mov *.mp4 *.mpeg *.mpeg4 *.mpg *.ogv *.vob *.webm *.wmv" 2>/dev/null)
 if-cancel-exit
+
+FILES=$(echo "$FILES" | sed -E 's/\.(3gp|avi|dat|dv|flv|m2v|m4v|mkv|mov|mp4|mpeg|mpeg4|mpg|ogv|vob|webm|wmv)\s/\.\1\n/gi' | sed 's/ $//g')
 
 DESTINATION=$(kdialog --icon=ks-video-rotate --title="Destination Video Files" --getexistingdirectory "$DIR" 2>/dev/null)
 if-cancel-exit


### PR DESCRIPTION
Apologies for taking a while, and for the commits being a mess. I've never really dabbled in Github stuff properly. Regardless, I've now gone ahead and fixed whitespace issues for all the scripts that I personally am aware of. I tested each one as well as I was able, though I only later realised that my directory path had no whitespace, so I was only really able to test whitespace related to filenames. `DVD_Tools-d.v.d.-assembler.sh` was one that I wasn't able to test, so it's possible that it doesn't work right. Otherwise, things *should* be all good.